### PR TITLE
Loose version range for requests library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='sap-business-entity-recognition-client-library',
       version=1.3,
       license='apache-2.0',
       install_requires=[
-          'requests~=2.0'
+          'requests~=2.31'
       ],
       packages=find_packages(
           exclude=['examples*']),

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ https://github.com/pypa/sampleproject
 from setuptools import setup, find_packages
 
 setup(name='sap-business-entity-recognition-client-library',
-      version=1.2,
+      version=1.3,
       license='apache-2.0',
       install_requires=[
-          'requests==2.26.0'
+          'requests~=2.0'
       ],
       packages=find_packages(
           exclude=['examples*']),


### PR DESCRIPTION
Since there is a vulnerability in requests `2.26.0` any dependent application might consider upgrading to `2.31.0` and above. Therefore, to unblock dependent projects we could specify a broader dependency range for the requests library.