### PR TITLE
Fixing batch inference file upload

### DIFF
--- a/examples/pretrained_model_inference.ipynb
+++ b/examples/pretrained_model_inference.ipynb
@@ -201,6 +201,8 @@
    },
    "outputs": [],
    "source": [
+    "model_name = \"sap_generic_entities\"\n",
+    "model_version = 1\n",
     "# Create Inference dataset\n",
     "response = my_ber_client.create_dataset(\"inference\")\n",
     "pprint(response.json())\n",
@@ -228,10 +230,13 @@
     "response = my_ber_client.get_inference_job(batch_inference_job_id)\n",
     "pprint(response.json())\n",
     "\n",
-    "#get inference batch job result\n",
-    "response = my_ber_client.get_batch_inference_job_result(batch_inference_job_id)\n",
+    "inference_job_status = response.json()[\"data\"][\"status\"]\n",
     "\n",
-    "pprint(response.json())"
+    "\n",
+    "#get inference batch job result\n",
+    "if inference_job_status == \"SUCCESS\":\n",
+    "    response = my_ber_client.get_batch_inference_job_result(batch_inference_job_id)\n",
+    "    pprint(response.json())"
    ]
   },
   {
@@ -272,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/sap_ber_client/ber_api_client.py
+++ b/sap_ber_client/ber_api_client.py
@@ -113,8 +113,9 @@ class BER_API_Client(CommonClient):
 
         self.logger.debug('Uploading the document {} to the dataset {}'.format(
             document_path, dataset_id))
+        document_name = document_path.split("/")[-1]
         response = self.session.post(self.path_to_url(DATASET_DOCUMENTS_ENDPOINT(dataset_id=dataset_id)),
-                                     files={'document': open(document_path, 'rb')})
+                                     files={'document': (document_name, open(document_path, 'rb'), "application/json")})
         response.raise_for_status()
         self.logger.debug('Successfully uploaded the document {} to the dataset {}, waiting for '
                           'the document processing'.format(document_path, dataset_id))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ https://github.com/pypa/sampleproject
 from setuptools import setup, find_packages
 
 setup(name='sap-business-entity-recognition-client-library',
-      version=1.3,
+      version=1.4,
       license='apache-2.0',
       install_requires=[
           'requests~=2.31'


### PR DESCRIPTION
File upload in batch inference was failing as the content-type of the document is not mentioned explicitly.
Updating the version of client library